### PR TITLE
fix: allow to accept routes and use tsnet's dialer

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ tsdnsproxy -authkey tskey-auth-YOUR-KEY
 - `TSDNSPROXY_OVERRIDE_DNS`: Override host DNS servers (comma-separated, defaults to host's resolvers)
 - `TSDNSPROXY_LISTEN_ADDRS`: Listen addresses (default: `tailscale`) - see Network Configuration
 - `TSDNSPROXY_HEALTH_ADDR`: Health check endpoint address (default: `:8080`)
+- `TSDNSPROXY_ACCEPT_ROUTES`: Accept subnet routes (default: `false`)
+- `TSDNSPROXY_USE_TS_DIALER`: Query DNS over tailnet routes (default: `false`)
 - `TSDNSPROXY_VERBOSE`: Enable verbose logging (default: `false`)
 
 ### Command Line Flags
@@ -262,6 +264,25 @@ Different teams see different DNS results:
   ]
 }
 ```
+
+### Split-Horizon DNS over 4via6
+
+Forwarding DNS queries over 4via6 allows DNS servers to run on overlapping IP or CIDR ranges. You need to enable `TSDNSPROXY_ACCEPT_ROUTES` to accept the 4via6 subnets and `TSDNSPROXY_USE_TS_DIALER` to send queries over tsnet.
+
+```json
+{
+  "site1.vpc": {
+    "dns": ["[fd7a:115c:a1e0:b1a:0:1:a0f:2]:53"],
+    "translateid": 1
+  },
+  "site2.vpc": {
+    "dns": ["[fd7a:115c:a1e0:b1a:0:2:a0f:2]:53"],
+    "translateid": 2
+  }
+}
+```
+
+In this case, Both DNS server for `site1.vpc` and `site2.vpc` run on `10.15.0.2/16 but it will be queried over 4via6. This setup is useful when a service discovery is enabled in your VPCs.
 
 ### IPv4-only Services via Tailscale IPv6
 

--- a/cmd/tsdnsproxy/main.go
+++ b/cmd/tsdnsproxy/main.go
@@ -1,26 +1,28 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
-	"bufio"
-	"net"
 
 	"github.com/rajsinghtech/tsdnsproxy/internal/backend"
 	"github.com/rajsinghtech/tsdnsproxy/internal/cache"
 	"github.com/rajsinghtech/tsdnsproxy/internal/constants"
 	"github.com/rajsinghtech/tsdnsproxy/internal/dns"
 	"github.com/rajsinghtech/tsdnsproxy/internal/grants"
+	"tailscale.com/client/local"
 	"tailscale.com/hostinfo"
+	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/ipn/store"
 	"tailscale.com/tsnet"
@@ -35,7 +37,7 @@ func envOr(key, defaultVal string) string {
 
 func getHostDNSServers() []string {
 	var servers []string
-	
+
 	// Try to read from /etc/resolv.conf (Linux/Unix)
 	if file, err := os.Open("/etc/resolv.conf"); err == nil {
 		defer func() {
@@ -59,7 +61,7 @@ func getHostDNSServers() []string {
 			return servers
 		}
 	}
-	
+
 	// Fallback to system DNS resolution
 	config, err := net.DefaultResolver.LookupNS(context.Background(), ".")
 	if err == nil && len(config) > 0 {
@@ -74,7 +76,7 @@ func getHostDNSServers() []string {
 			return servers
 		}
 	}
-	
+
 	// Final fallback to common public DNS
 	log.Println("warning: could not determine host DNS servers, falling back to 8.8.8.8:53")
 	return []string{"8.8.8.8:53"}
@@ -117,16 +119,17 @@ func main() {
 	hostinfo.SetApp("tsdnsproxy")
 
 	var (
-		authKey     = flag.String("authkey", os.Getenv("TS_AUTHKEY"), "tailscale auth key")
-		hostname    = flag.String("hostname", envOr("TSDNSPROXY_HOSTNAME", "tsdnsproxy"), "hostname on tailnet")
-		stateDir    = flag.String("statedir", envOr("TSDNSPROXY_STATE_DIR", "/var/lib/tsdnsproxy"), "state directory")
-		state       = flag.String("state", os.Getenv("TSDNSPROXY_STATE"), "state storage (e.g., kube:<secret-name>)")
-		controlURL  = flag.String("controlurl", os.Getenv("TS_CONTROLURL"), "optional alternate control server URL")
-		overrideDNS = flag.String("override-dns", envOr("TSDNSPROXY_OVERRIDE_DNS", ""), "override DNS servers (comma-separated, defaults to host resolvers)")
-		cacheExpiry = flag.Duration("cache-expiry", constants.DefaultCacheExpiry, "whois cache expiry duration")
-		healthAddr  = flag.String("health-addr", envOr("TSDNSPROXY_HEALTH_ADDR", ":8080"), "health check endpoint address")
-		listenAddrs = flag.String("listen-addrs", envOr("TSDNSPROXY_LISTEN_ADDRS", "tailscale"), "listen addresses (comma-separated: tailscale,0.0.0.0:53,127.0.0.1:5353)")
-		verbose     = flag.Bool("verbose", envOr("TSDNSPROXY_VERBOSE", "false") == "true", "enable verbose logging")
+		authKey      = flag.String("authkey", os.Getenv("TS_AUTHKEY"), "tailscale auth key")
+		hostname     = flag.String("hostname", envOr("TSDNSPROXY_HOSTNAME", "tsdnsproxy"), "hostname on tailnet")
+		stateDir     = flag.String("statedir", envOr("TSDNSPROXY_STATE_DIR", "/var/lib/tsdnsproxy"), "state directory")
+		state        = flag.String("state", os.Getenv("TSDNSPROXY_STATE"), "state storage (e.g., kube:<secret-name>)")
+		controlURL   = flag.String("controlurl", os.Getenv("TS_CONTROLURL"), "optional alternate control server URL")
+		overrideDNS  = flag.String("override-dns", envOr("TSDNSPROXY_OVERRIDE_DNS", ""), "override DNS servers (comma-separated, defaults to host resolvers)")
+		cacheExpiry  = flag.Duration("cache-expiry", constants.DefaultCacheExpiry, "whois cache expiry duration")
+		healthAddr   = flag.String("health-addr", envOr("TSDNSPROXY_HEALTH_ADDR", ":8080"), "health check endpoint address")
+		listenAddrs  = flag.String("listen-addrs", envOr("TSDNSPROXY_LISTEN_ADDRS", "tailscale"), "listen addresses (comma-separated: tailscale,0.0.0.0:53,127.0.0.1:5353)")
+		acceptRoutes = flag.Bool("accept-routes", envOr("TSDNSPROXY_ACCEPT_ROUTES", "false") == "true", "accept subnet routes")
+		verbose      = flag.Bool("verbose", envOr("TSDNSPROXY_VERBOSE", "false") == "true", "enable verbose logging")
 	)
 	flag.Parse()
 
@@ -235,6 +238,14 @@ func main() {
 		}
 	}
 
+	if *acceptRoutes {
+		log.Print("accepting subnet routes...")
+
+		if err := enableAcceptRoutes(ctx, lc); err != nil {
+			log.Fatalf("failed to enable accepting routes: %v", err)
+		}
+	}
+
 	dnsServer := &dns.Server{
 		TSServer:    s,
 		LocalClient: lc,
@@ -248,7 +259,7 @@ func main() {
 	healthServer := startHealthServer(ctx, *healthAddr, s)
 
 	// Start DNS server (handles both UDP and TCP)
-	log.Printf("starting DNS server")
+	log.Printf("starting DNS server: %v", *listenAddrs)
 	if err := dnsServer.RunWithAddrs(ctx, *listenAddrs, status); err != nil {
 		log.Printf("DNS server error: %v", err)
 	}
@@ -259,6 +270,29 @@ func main() {
 		log.Printf("health shutdown: %v", err)
 	}
 
+}
+
+// Enable --accept-routes to be able to route DNS traffic via subnet routes in tailnet
+func enableAcceptRoutes(ctx context.Context, lc *local.Client) error {
+	prefs, err := lc.GetPrefs(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !prefs.RouteAll {
+		_, err := lc.EditPrefs(ctx, &ipn.MaskedPrefs{
+			Prefs: ipn.Prefs{
+				RouteAll: true,
+			},
+			RouteAllSet: true,
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func logf(verbose bool) func(format string, args ...any) {

--- a/cmd/tsdnsproxy/main.go
+++ b/cmd/tsdnsproxy/main.go
@@ -129,6 +129,7 @@ func main() {
 		healthAddr   = flag.String("health-addr", envOr("TSDNSPROXY_HEALTH_ADDR", ":8080"), "health check endpoint address")
 		listenAddrs  = flag.String("listen-addrs", envOr("TSDNSPROXY_LISTEN_ADDRS", "tailscale"), "listen addresses (comma-separated: tailscale,0.0.0.0:53,127.0.0.1:5353)")
 		acceptRoutes = flag.Bool("accept-routes", envOr("TSDNSPROXY_ACCEPT_ROUTES", "false") == "true", "accept subnet routes")
+		useTSDialer  = flag.Bool("use-ts-dialer", envOr("TSDNSPROXY_USE_TS_DIALER", "false") == "true", "use Tailscale's dialer to allow to query DNS over tailnet")
 		verbose      = flag.Bool("verbose", envOr("TSDNSPROXY_VERBOSE", "false") == "true", "enable verbose logging")
 	)
 	flag.Parse()
@@ -205,7 +206,14 @@ func main() {
 		defaultServers = getHostDNSServers()
 		log.Printf("using host DNS servers: %v", defaultServers)
 	}
-	backendMgr := backend.NewManager(defaultServers)
+
+	var dnsDialer backend.DNSDialer
+	if *useTSDialer {
+		log.Printf("using ts dialer to query DNS over tailnet")
+		dnsDialer = s
+	}
+
+	backendMgr := backend.NewManager(defaultServers, dnsDialer)
 	defer backendMgr.Close()
 
 	grantParser := grants.NewParser()

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+type DNSDialer interface {
+	Dial(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+type netDialer struct {
+	net.Dialer
+}
+
+func (d netDialer) Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.DialContext(ctx, network, address)
+}
+
 // Backend represents a DNS backend that can handle queries
 type Backend interface {
 	// Query sends a DNS query and returns the response
@@ -30,18 +42,20 @@ type Manager struct {
 	mu              sync.RWMutex
 	unhealthy       map[string]*backendHealth
 	done            chan struct{}
+	dnsDialer       DNSDialer
 }
 
 // NewManager creates a new backend manager
-func NewManager(defaultServers []string) *Manager {
+func NewManager(defaultServers []string, dnsDialer DNSDialer) *Manager {
 	m := &Manager{
 		unhealthy: make(map[string]*backendHealth),
 		done:      make(chan struct{}),
+		dnsDialer: dnsDialer,
 	}
 
 	for _, server := range defaultServers {
 		if server != "" {
-			m.defaultBackends = append(m.defaultBackends, NewUDPBackend(server))
+			m.defaultBackends = append(m.defaultBackends, NewUDPBackend(server, dnsDialer))
 		}
 	}
 
@@ -86,7 +100,7 @@ func (m *Manager) CreateBackends(servers []string) []Backend {
 	var backends []Backend
 	for _, server := range servers {
 		if server != "" {
-			backends = append(backends, NewUDPBackend(server))
+			backends = append(backends, NewUDPBackend(server, m.dnsDialer))
 		}
 	}
 	return backends
@@ -163,20 +177,22 @@ func (m *Manager) Close() {
 
 // UDPBackend implements a UDP DNS backend
 type UDPBackend struct {
-	server  string
-	timeout time.Duration
+	server    string
+	timeout   time.Duration
+	dnsDialer DNSDialer
 }
 
 // NewUDPBackend creates a new UDP DNS backend
-func NewUDPBackend(server string) *UDPBackend {
+func NewUDPBackend(server string, dnsDialer DNSDialer) *UDPBackend {
 	// Ensure server has port
 	if _, _, err := net.SplitHostPort(server); err != nil {
 		server = net.JoinHostPort(server, "53")
 	}
 
 	return &UDPBackend{
-		server:  server,
-		timeout: 2 * time.Second,
+		server:    server,
+		timeout:   2 * time.Second,
+		dnsDialer: dnsDialer,
 	}
 }
 
@@ -186,7 +202,12 @@ func (b *UDPBackend) Query(ctx context.Context, query []byte) ([]byte, error) {
 		deadline = d
 	}
 
-	conn, err := net.Dial("udp", b.server)
+	var d DNSDialer = netDialer{net.Dialer{}}
+	if b.dnsDialer != nil {
+		d = b.dnsDialer
+	}
+
+	conn, err := d.Dial(ctx, "udp", b.server)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", b.server, err)
 	}


### PR DESCRIPTION
Hi @rajsinghtech,

When I was testing a particular setup with Amazon VPC + AWS Cloud Map (service discovery) for multiple VPCs that have overlapping CIDR ranges, I found this solution that translates IP addresses into 4via6 addresses.

I tested the tsdnsproxy and found the problem: it can't route DNS traffic to 4via6 subnets. I need the 4via6 support because DNS server runs on overlapping CIDR ranges.

Looking into the codebase and found the cause:
- `tsdnsproxy` doesn't accept routes so it can't see 4via6 subnets
- `tsdnsproxy` doesn't query DNS over tsnet because it simply calls the underlying OS's network stack

In this PR, I added necessary changes to make it work. I tested with my Amazon VPC + Cloud Map and it works well.

I hope this finds you well and get this merged. Feel free to modify my work to adjust your style as needed.

Thank you for your great work!